### PR TITLE
Add mobile card layout

### DIFF
--- a/Website/app/globals.css
+++ b/Website/app/globals.css
@@ -92,3 +92,24 @@ body {
     @apply bg-gray-100
   }
 }
+
+@media (max-width: 768px) {
+  .card {
+    @apply flex flex-col border rounded-lg p-4 mb-4;
+  }
+  .card-header {
+    @apply font-bold text-lg mb-2;
+  }
+  .card-content {
+    @apply flex flex-col gap-2;
+  }
+  .card-row {
+    @apply flex flex-row justify-between;
+  }
+  .card-label {
+    @apply font-medium;
+  }
+  .card-value {
+    @apply text-right;
+  }
+}

--- a/Website/components/Section.tsx
+++ b/Website/components/Section.tsx
@@ -35,7 +35,7 @@ function Section({
     return <div ref={contentRef} className="mb-5">
         <a className="flex flex-row gap-2 items-center hover:underline" href={`?selected=${entity.SchemaName}`}><Link /> <h2 className="text-xl">{entity.DisplayName} ({entity.SchemaName})</h2></a>
         <p className="my-4">{entity.Description}</p>
-        <Table className="border">
+        <Table className="border hidden md:table">
             <TableHeader>
                 <TableRow className="bg-gray-100">
                     <TableHead className="w-1/6 text-black font-bold">Display Name</TableHead>

--- a/Website/components/attributes/BooleanAttribute.tsx
+++ b/Website/components/attributes/BooleanAttribute.tsx
@@ -2,18 +2,51 @@ import { BooleanAttributeType } from "@/lib/Types"
 import { TableCell, TableRow } from "../ui/table"
 
 export default function ChoiceAttribute({ attribute }: { attribute: BooleanAttributeType}) {
-    return <TableRow>
-        <TableCell>{attribute.DisplayName}</TableCell>
-        <TableCell>{attribute.SchemaName}</TableCell>
-        <TableCell className="flex flex-col">
-            <div className="grid grid-cols-2 mb-2">
-                <p className="col-span-2 font-bold">Boolean</p>
-                <p>{attribute.TrueLabel}</p>
-                <p>True{attribute.DefaultValue === true ? " (Default)" : ""}</p>
-                <p>{attribute.FalseLabel}</p>
-                <p>False{attribute.DefaultValue === false ? " (Default)" : ""}</p>
+    return (
+        <>
+            <TableRow className="hidden md:table-row">
+                <TableCell>{attribute.DisplayName}</TableCell>
+                <TableCell>{attribute.SchemaName}</TableCell>
+                <TableCell className="flex flex-col">
+                    <div className="grid grid-cols-2 mb-2">
+                        <p className="col-span-2 font-bold">Boolean</p>
+                        <p>{attribute.TrueLabel}</p>
+                        <p>True{attribute.DefaultValue === true ? " (Default)" : ""}</p>
+                        <p>{attribute.FalseLabel}</p>
+                        <p>False{attribute.DefaultValue === false ? " (Default)" : ""}</p>
+                    </div>
+                </TableCell>
+                <TableCell>{attribute.Description}</TableCell>
+            </TableRow>
+            <div className="card md:hidden">
+                <div className="card-header">{attribute.DisplayName}</div>
+                <div className="card-content">
+                    <div className="card-row">
+                        <span className="card-label">Schema Name:</span>
+                        <span className="card-value">{attribute.SchemaName}</span>
+                    </div>
+                    <div className="card-row">
+                        <span className="card-label">Type:</span>
+                        <span className="card-value">Boolean</span>
+                    </div>
+                    <div className="card-row">
+                        <span className="card-label">True Label:</span>
+                        <span className="card-value">{attribute.TrueLabel}</span>
+                    </div>
+                    <div className="card-row">
+                        <span className="card-label">False Label:</span>
+                        <span className="card-value">{attribute.FalseLabel}</span>
+                    </div>
+                    <div className="card-row">
+                        <span className="card-label">Default Value:</span>
+                        <span className="card-value">{attribute.DefaultValue ? "True" : "False"}</span>
+                    </div>
+                    <div className="card-row">
+                        <span className="card-label">Description:</span>
+                        <span className="card-value">{attribute.Description}</span>
+                    </div>
+                </div>
             </div>
-        </TableCell>
-        <TableCell>{attribute.Description}</TableCell>
-    </TableRow>
+        </>
+    )
 }

--- a/Website/components/attributes/ChoiceAttribute.tsx
+++ b/Website/components/attributes/ChoiceAttribute.tsx
@@ -2,24 +2,52 @@ import { ChoiceAttributeType } from "@/lib/Types"
 import { TableCell, TableRow } from "../ui/table"
 
 export default function ChoiceAttribute({ attribute }: { attribute: ChoiceAttributeType }) {
-    return <TableRow>
-        <TableCell>{attribute.DisplayName}</TableCell>
-        <TableCell>{attribute.SchemaName}</TableCell>
-        <TableCell className="flex flex-col">
-            <div className="grid grid-cols-[auto_1] mb-1 gap-y-1">
-                <p className="col-span-2">{attribute.Type}-select</p>
-                <p className="font-bold">Name</p>
-                <p className="font-bold">Value</p>
-                {attribute.Options.map(option =>
-                    <div className="contents" key={option.Value}>
-                        <p>{option.Name}{option.Value == attribute.DefaultValue ? " (Default)" : ""}</p>
-                        <p>{option.Value}{GetColorBox(option.Color)}</p>
-                        {option.Description && <p className="col-span-2 italic">{option.Description}</p>}
-                    </div>)}
+    return (
+        <>
+            <TableRow className="hidden md:table-row">
+                <TableCell>{attribute.DisplayName}</TableCell>
+                <TableCell>{attribute.SchemaName}</TableCell>
+                <TableCell className="flex flex-col">
+                    <div className="grid grid-cols-[auto_1] mb-1 gap-y-1">
+                        <p className="col-span-2">{attribute.Type}-select</p>
+                        <p className="font-bold">Name</p>
+                        <p className="font-bold">Value</p>
+                        {attribute.Options.map(option =>
+                            <div className="contents" key={option.Value}>
+                                <p>{option.Name}{option.Value == attribute.DefaultValue ? " (Default)" : ""}</p>
+                                <p>{option.Value}{GetColorBox(option.Color)}</p>
+                                {option.Description && <p className="col-span-2 italic">{option.Description}</p>}
+                            </div>)}
+                    </div>
+                </TableCell>
+                <TableCell>{attribute.Description}</TableCell>
+            </TableRow>
+            <div className="card md:hidden">
+                <div className="card-header">{attribute.DisplayName}</div>
+                <div className="card-content">
+                    <div className="card-row">
+                        <span className="card-label">Schema Name:</span>
+                        <span className="card-value">{attribute.SchemaName}</span>
+                    </div>
+                    <div className="card-row">
+                        <span className="card-label">Type:</span>
+                        <span className="card-value">{attribute.Type}-select</span>
+                    </div>
+                    {attribute.Options.map(option => (
+                        <div className="card-row" key={option.Value}>
+                            <span className="card-label">{option.Name}{option.Value == attribute.DefaultValue ? " (Default)" : ""}:</span>
+                            <span className="card-value">{option.Value}{GetColorBox(option.Color)}</span>
+                            {option.Description && <span className="card-value italic">{option.Description}</span>}
+                        </div>
+                    ))}
+                    <div className="card-row">
+                        <span className="card-label">Description:</span>
+                        <span className="card-value">{attribute.Description}</span>
+                    </div>
+                </div>
             </div>
-        </TableCell>
-        <TableCell>{attribute.Description}</TableCell>
-    </TableRow>
+        </>
+    )
 }
 
 function GetColorBox(color: string | null) {

--- a/Website/components/attributes/DateTimeAttribute.tsx
+++ b/Website/components/attributes/DateTimeAttribute.tsx
@@ -2,10 +2,35 @@ import { DateTimeAttributeType } from "@/lib/Types";
 import { TableCell, TableRow } from "../ui/table";
 
 export default function DateTimeAttribute({ attribute } : { attribute: DateTimeAttributeType }) {
-    return <TableRow>
-        <TableCell>{attribute.DisplayName}</TableCell>
-        <TableCell>{attribute.SchemaName}</TableCell>
-        <TableCell>{attribute.Format} - {attribute.Behavior}</TableCell>
-        <TableCell>{attribute.Description}</TableCell>
-        </TableRow>
+    return (
+        <>
+            <TableRow className="hidden md:table-row">
+                <TableCell>{attribute.DisplayName}</TableCell>
+                <TableCell>{attribute.SchemaName}</TableCell>
+                <TableCell>{attribute.Format} - {attribute.Behavior}</TableCell>
+                <TableCell>{attribute.Description}</TableCell>
+            </TableRow>
+            <div className="card md:hidden">
+                <div className="card-header">{attribute.DisplayName}</div>
+                <div className="card-content">
+                    <div className="card-row">
+                        <span className="card-label">Schema Name:</span>
+                        <span className="card-value">{attribute.SchemaName}</span>
+                    </div>
+                    <div className="card-row">
+                        <span className="card-label">Format:</span>
+                        <span className="card-value">{attribute.Format}</span>
+                    </div>
+                    <div className="card-row">
+                        <span className="card-label">Behavior:</span>
+                        <span className="card-value">{attribute.Behavior}</span>
+                    </div>
+                    <div className="card-row">
+                        <span className="card-label">Description:</span>
+                        <span className="card-value">{attribute.Description}</span>
+                    </div>
+                </div>
+            </div>
+        </>
+    )
 }

--- a/Website/components/attributes/DecimalAttribute.tsx
+++ b/Website/components/attributes/DecimalAttribute.tsx
@@ -7,15 +7,48 @@ export default function MoneyAttribute({ attribute }: { attribute: DecimalAttrib
         ? FormatMoney 
         : FormatDecimal
 
-    return <TableRow>
-        <TableCell>{attribute.DisplayName}</TableCell>
-        <TableCell>{attribute.SchemaName}</TableCell>
-        <TableCell className="flex flex-col">
-            <p>{attribute.Type} ({formatNumber(attribute.MinValue)} to {formatNumber(attribute.MaxValue)})</p>
-            <p>Precision: {attribute.Precision}</p>
-        </TableCell>
-        <TableCell>{attribute.Description}</TableCell>
-    </TableRow>
+    return (
+        <>
+            <TableRow className="hidden md:table-row">
+                <TableCell>{attribute.DisplayName}</TableCell>
+                <TableCell>{attribute.SchemaName}</TableCell>
+                <TableCell className="flex flex-col">
+                    <p>{attribute.Type} ({formatNumber(attribute.MinValue)} to {formatNumber(attribute.MaxValue)})</p>
+                    <p>Precision: {attribute.Precision}</p>
+                </TableCell>
+                <TableCell>{attribute.Description}</TableCell>
+            </TableRow>
+            <div className="card md:hidden">
+                <div className="card-header">{attribute.DisplayName}</div>
+                <div className="card-content">
+                    <div className="card-row">
+                        <span className="card-label">Schema Name:</span>
+                        <span className="card-value">{attribute.SchemaName}</span>
+                    </div>
+                    <div className="card-row">
+                        <span className="card-label">Type:</span>
+                        <span className="card-value">{attribute.Type}</span>
+                    </div>
+                    <div className="card-row">
+                        <span className="card-label">Min Value:</span>
+                        <span className="card-value">{formatNumber(attribute.MinValue)}</span>
+                    </div>
+                    <div className="card-row">
+                        <span className="card-label">Max Value:</span>
+                        <span className="card-value">{formatNumber(attribute.MaxValue)}</span>
+                    </div>
+                    <div className="card-row">
+                        <span className="card-label">Precision:</span>
+                        <span className="card-value">{attribute.Precision}</span>
+                    </div>
+                    <div className="card-row">
+                        <span className="card-label">Description:</span>
+                        <span className="card-value">{attribute.Description}</span>
+                    </div>
+                </div>
+            </div>
+        </>
+    )
 }
 
 function FormatMoney(number: number) {

--- a/Website/components/attributes/FileAttribute.tsx
+++ b/Website/components/attributes/FileAttribute.tsx
@@ -2,10 +2,35 @@ import { FileAttributeType } from "@/lib/Types";
 import { TableCell, TableRow } from "../ui/table";
 
 export default function FileAttribute({ attribute } : { attribute: FileAttributeType }) {
-    return <TableRow>
-        <TableCell>{attribute.DisplayName}</TableCell>
-        <TableCell>{attribute.SchemaName}</TableCell>
-        <TableCell>File (Max {attribute.MaxSize}KB)</TableCell>
-        <TableCell>{attribute.Description}</TableCell>
-        </TableRow>
+    return (
+        <>
+            <TableRow className="hidden md:table-row">
+                <TableCell>{attribute.DisplayName}</TableCell>
+                <TableCell>{attribute.SchemaName}</TableCell>
+                <TableCell>File (Max {attribute.MaxSize}KB)</TableCell>
+                <TableCell>{attribute.Description}</TableCell>
+            </TableRow>
+            <div className="card md:hidden">
+                <div className="card-header">{attribute.DisplayName}</div>
+                <div className="card-content">
+                    <div className="card-row">
+                        <span className="card-label">Schema Name:</span>
+                        <span className="card-value">{attribute.SchemaName}</span>
+                    </div>
+                    <div className="card-row">
+                        <span className="card-label">Type:</span>
+                        <span className="card-value">File</span>
+                    </div>
+                    <div className="card-row">
+                        <span className="card-label">Max Size:</span>
+                        <span className="card-value">{attribute.MaxSize}KB</span>
+                    </div>
+                    <div className="card-row">
+                        <span className="card-label">Description:</span>
+                        <span className="card-value">{attribute.Description}</span>
+                    </div>
+                </div>
+            </div>
+        </>
+    )
 }

--- a/Website/components/attributes/GenericAttribute.tsx
+++ b/Website/components/attributes/GenericAttribute.tsx
@@ -2,10 +2,31 @@ import { GenericAttributeType } from "@/lib/Types";
 import { TableCell, TableRow } from "../ui/table";
 
 export default function GenericAttribute({ attribute } : { attribute: GenericAttributeType }) {
-    return <TableRow>
-        <TableCell>{attribute.DisplayName}</TableCell>
-        <TableCell>{attribute.SchemaName}</TableCell>
-        <TableCell>Generic {attribute.Type}</TableCell>
-        <TableCell>{attribute.Description}</TableCell>
-        </TableRow>
+    return (
+        <>
+            <TableRow className="hidden md:table-row">
+                <TableCell>{attribute.DisplayName}</TableCell>
+                <TableCell>{attribute.SchemaName}</TableCell>
+                <TableCell>Generic {attribute.Type}</TableCell>
+                <TableCell>{attribute.Description}</TableCell>
+            </TableRow>
+            <div className="card md:hidden">
+                <div className="card-header">{attribute.DisplayName}</div>
+                <div className="card-content">
+                    <div className="card-row">
+                        <span className="card-label">Schema Name:</span>
+                        <span className="card-value">{attribute.SchemaName}</span>
+                    </div>
+                    <div className="card-row">
+                        <span className="card-label">Type:</span>
+                        <span className="card-value">Generic {attribute.Type}</span>
+                    </div>
+                    <div className="card-row">
+                        <span className="card-label">Description:</span>
+                        <span className="card-value">{attribute.Description}</span>
+                    </div>
+                </div>
+            </div>
+        </>
+    )
 }

--- a/Website/components/attributes/IntegerAttribute.tsx
+++ b/Website/components/attributes/IntegerAttribute.tsx
@@ -2,12 +2,41 @@ import { IntegerAttributeType } from "@/lib/Types"
 import { TableCell, TableRow } from "../ui/table"
 
 export default function IntegerAttribute({ attribute } : { attribute: IntegerAttributeType }) {
-    return <TableRow>
-        <TableCell>{attribute.DisplayName}</TableCell>
-        <TableCell>{attribute.SchemaName}</TableCell>
-        <TableCell>{attribute.Format} ({FormatNumber(attribute.MinValue)} to {FormatNumber(attribute.MaxValue)})</TableCell>
-        <TableCell>{attribute.Description}</TableCell>
-        </TableRow>
+    return (
+        <>
+            <TableRow className="hidden md:table-row">
+                <TableCell>{attribute.DisplayName}</TableCell>
+                <TableCell>{attribute.SchemaName}</TableCell>
+                <TableCell>{attribute.Format} ({FormatNumber(attribute.MinValue)} to {FormatNumber(attribute.MaxValue)})</TableCell>
+                <TableCell>{attribute.Description}</TableCell>
+            </TableRow>
+            <div className="card md:hidden">
+                <div className="card-header">{attribute.DisplayName}</div>
+                <div className="card-content">
+                    <div className="card-row">
+                        <span className="card-label">Schema Name:</span>
+                        <span className="card-value">{attribute.SchemaName}</span>
+                    </div>
+                    <div className="card-row">
+                        <span className="card-label">Format:</span>
+                        <span className="card-value">{attribute.Format}</span>
+                    </div>
+                    <div className="card-row">
+                        <span className="card-label">Min Value:</span>
+                        <span className="card-value">{FormatNumber(attribute.MinValue)}</span>
+                    </div>
+                    <div className="card-row">
+                        <span className="card-label">Max Value:</span>
+                        <span className="card-value">{FormatNumber(attribute.MaxValue)}</span>
+                    </div>
+                    <div className="card-row">
+                        <span className="card-label">Description:</span>
+                        <span className="card-value">{attribute.Description}</span>
+                    </div>
+                </div>
+            </div>
+        </>
+    )
 }
 
 function FormatNumber(number: number) {

--- a/Website/components/attributes/LookupAttribute.tsx
+++ b/Website/components/attributes/LookupAttribute.tsx
@@ -3,24 +3,60 @@ import { Button } from "../ui/button"
 import { TableCell, TableRow } from "../ui/table"
 
 export default function LookupAttribute({ attribute, onSelect } : { attribute: LookupAttributeType, onSelect: (entity: string) => void }) {
-    return <TableRow>
-        <TableCell>{attribute.DisplayName}</TableCell>
-        <TableCell>{attribute.SchemaName}</TableCell>
-        <TableCell className="flex flex-col">
-            <p className="font-bold">Lookup</p>
-            <div className="flex flex-col items-start">
-                {attribute.Targets
-                .sort((a, b) => a.ShouldLink === b.ShouldLink ? 0 : a.ShouldLink ? -1 : 1)
-                .map(target =>
-                    target.ShouldLink 
-                    ? <Button 
-                        key={target.Name} 
-                        variant="ghost" 
-                        className="p-0 text-base text-blue-600 underline dark:text-blue-500 hover:no-underline" 
-                        onClick={() => onSelect(target.Name)}>{target.Name}</Button>
-                    : <p className="text-base" key={target.Name}>{target.Name}</p>)}
+    return (
+        <>
+            <TableRow className="hidden md:table-row">
+                <TableCell>{attribute.DisplayName}</TableCell>
+                <TableCell>{attribute.SchemaName}</TableCell>
+                <TableCell className="flex flex-col">
+                    <p className="font-bold">Lookup</p>
+                    <div className="flex flex-col items-start">
+                        {attribute.Targets
+                        .sort((a, b) => a.ShouldLink === b.ShouldLink ? 0 : a.ShouldLink ? -1 : 1)
+                        .map(target =>
+                            target.ShouldLink 
+                            ? <Button 
+                                key={target.Name} 
+                                variant="ghost" 
+                                className="p-0 text-base text-blue-600 underline dark:text-blue-500 hover:no-underline" 
+                                onClick={() => onSelect(target.Name)}>{target.Name}</Button>
+                            : <p className="text-base" key={target.Name}>{target.Name}</p>)}
+                    </div>
+                </TableCell>
+                <TableCell>{attribute.Description}</TableCell>
+            </TableRow>
+            <div className="card md:hidden">
+                <div className="card-header">{attribute.DisplayName}</div>
+                <div className="card-content">
+                    <div className="card-row">
+                        <span className="card-label">Schema Name:</span>
+                        <span className="card-value">{attribute.SchemaName}</span>
+                    </div>
+                    <div className="card-row">
+                        <span className="card-label">Type:</span>
+                        <span className="card-value">Lookup</span>
+                    </div>
+                    <div className="card-row">
+                        <span className="card-label">Targets:</span>
+                        <span className="card-value">
+                            {attribute.Targets
+                            .sort((a, b) => a.ShouldLink === b.ShouldLink ? 0 : a.ShouldLink ? -1 : 1)
+                            .map(target =>
+                                target.ShouldLink 
+                                ? <Button 
+                                    key={target.Name} 
+                                    variant="ghost" 
+                                    className="p-0 text-base text-blue-600 underline dark:text-blue-500 hover:no-underline" 
+                                    onClick={() => onSelect(target.Name)}>{target.Name}</Button>
+                                : <p className="text-base" key={target.Name}>{target.Name}</p>)}
+                        </span>
+                    </div>
+                    <div className="card-row">
+                        <span className="card-label">Description:</span>
+                        <span className="card-value">{attribute.Description}</span>
+                    </div>
+                </div>
             </div>
-        </TableCell>
-        <TableCell>{attribute.Description}</TableCell>
-    </TableRow>
+        </>
+    )
 }

--- a/Website/components/attributes/StatusAttribute.tsx
+++ b/Website/components/attributes/StatusAttribute.tsx
@@ -10,22 +10,52 @@ export default function StatusAttribute({ attribute }: { attribute: StatusAttrib
         return acc
     }, {} as Record<string, StatusOption[]>)
 
-    return <TableRow>
-        <TableCell>{attribute.DisplayName}</TableCell>
-        <TableCell>{attribute.SchemaName}</TableCell>
-        <TableCell className="flex flex-col">
-            {groupedOptions && Object.keys(groupedOptions).map(state =>
-                <div className="grid grid-cols-2 mb-4 gap-y-1" key={state}>
-                    <p className="font-bold col-span-2">{state}</p>
-                    <p className="font-bold">Name</p>
-                    <p className="font-bold">Value</p>
-                    {groupedOptions[state].map(option =>
-                        <div className="contents" key={option.Value}>
-                            <p>{option.Name}</p>
-                            <p>{option.Value}</p>
+    return (
+        <>
+            <TableRow className="hidden md:table-row">
+                <TableCell>{attribute.DisplayName}</TableCell>
+                <TableCell>{attribute.SchemaName}</TableCell>
+                <TableCell className="flex flex-col">
+                    {groupedOptions && Object.keys(groupedOptions).map(state =>
+                        <div className="grid grid-cols-2 mb-4 gap-y-1" key={state}>
+                            <p className="font-bold col-span-2">{state}</p>
+                            <p className="font-bold">Name</p>
+                            <p className="font-bold">Value</p>
+                            {groupedOptions[state].map(option =>
+                                <div className="contents" key={option.Value}>
+                                    <p>{option.Name}</p>
+                                    <p>{option.Value}</p>
+                                </div>)}
                         </div>)}
-                </div>)}
-        </TableCell>
-        <TableCell>{attribute.Description}</TableCell>
-    </TableRow>
+                </TableCell>
+                <TableCell>{attribute.Description}</TableCell>
+            </TableRow>
+            <div className="card md:hidden">
+                <div className="card-header">{attribute.DisplayName}</div>
+                <div className="card-content">
+                    <div className="card-row">
+                        <span className="card-label">Schema Name:</span>
+                        <span className="card-value">{attribute.SchemaName}</span>
+                    </div>
+                    {groupedOptions && Object.keys(groupedOptions).map(state => (
+                        <div key={state}>
+                            <div className="card-row">
+                                <span className="card-label">{state}:</span>
+                            </div>
+                            {groupedOptions[state].map(option => (
+                                <div className="card-row" key={option.Value}>
+                                    <span className="card-label">{option.Name}:</span>
+                                    <span className="card-value">{option.Value}</span>
+                                </div>
+                            ))}
+                        </div>
+                    ))}
+                    <div className="card-row">
+                        <span className="card-label">Description:</span>
+                        <span className="card-value">{attribute.Description}</span>
+                    </div>
+                </div>
+            </div>
+        </>
+    )
 }

--- a/Website/components/attributes/StringAttribute.tsx
+++ b/Website/components/attributes/StringAttribute.tsx
@@ -2,10 +2,31 @@ import { StringAttributeType } from "@/lib/Types";
 import { TableCell, TableRow } from "../ui/table";
 
 export default function StringAttribute({ attribute } : { attribute: StringAttributeType }) {
-    return <TableRow>
-        <TableCell>{attribute.DisplayName}</TableCell>
-        <TableCell>{attribute.SchemaName}</TableCell>
-        <TableCell>Text ({attribute.MaxLength}){attribute.Format !== "Text" ? ` - ${attribute.Format}` : ""}</TableCell>
-        <TableCell>{attribute.Description}</TableCell>
-        </TableRow>
+    return (
+        <>
+            <TableRow className="hidden md:table-row">
+                <TableCell>{attribute.DisplayName}</TableCell>
+                <TableCell>{attribute.SchemaName}</TableCell>
+                <TableCell>Text ({attribute.MaxLength}){attribute.Format !== "Text" ? ` - ${attribute.Format}` : ""}</TableCell>
+                <TableCell>{attribute.Description}</TableCell>
+            </TableRow>
+            <div className="card md:hidden">
+                <div className="card-header">{attribute.DisplayName}</div>
+                <div className="card-content">
+                    <div className="card-row">
+                        <span className="card-label">Schema Name:</span>
+                        <span className="card-value">{attribute.SchemaName}</span>
+                    </div>
+                    <div className="card-row">
+                        <span className="card-label">Type:</span>
+                        <span className="card-value">Text ({attribute.MaxLength}){attribute.Format !== "Text" ? ` - ${attribute.Format}` : ""}</span>
+                    </div>
+                    <div className="card-row">
+                        <span className="card-label">Description:</span>
+                        <span className="card-value">{attribute.Description}</span>
+                    </div>
+                </div>
+            </div>
+        </>
+    )
 }


### PR DESCRIPTION
Implement a card layout for mobile view to replace the current table-focused UI.

* **Global Styles**
  - Add styles for card layout in `Website/app/globals.css`.
  - Add media query to apply card layout styles for screens smaller than 768px.

* **BooleanAttribute Component**
  - Add card layout for mobile view in `Website/components/attributes/BooleanAttribute.tsx`.

* **ChoiceAttribute Component**
  - Add card layout for mobile view in `Website/components/attributes/ChoiceAttribute.tsx`.

* **DateTimeAttribute Component**
  - Add card layout for mobile view in `Website/components/attributes/DateTimeAttribute.tsx`.

* **DecimalAttribute Component**
  - Add card layout for mobile view in `Website/components/attributes/DecimalAttribute.tsx`.

* **FileAttribute Component**
  - Add card layout for mobile view in `Website/components/attributes/FileAttribute.tsx`.

* **GenericAttribute Component**
  - Add card layout for mobile view in `Website/components/attributes/GenericAttribute.tsx`.

* **IntegerAttribute Component**
  - Add card layout for mobile view in `Website/components/attributes/IntegerAttribute.tsx`.

* **LookupAttribute Component**
  - Add card layout for mobile view in `Website/components/attributes/LookupAttribute.tsx`.

* **StatusAttribute Component**
  - Add card layout for mobile view in `Website/components/attributes/StatusAttribute.tsx`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/delegateas/DataModelViewer/pull/1?shareId=e43a850e-4ce4-4fba-8a88-164aa284ffe5).