### PR TITLE
Grupperingsændringer og standard sortering på tabeller

### DIFF
--- a/Generator/DataverseService.cs
+++ b/Generator/DataverseService.cs
@@ -170,7 +170,7 @@ namespace Generator
 
                     var logicalNames = tables[1].Split(',', StringSplitOptions.RemoveEmptyEntries);
                     foreach (var logicalName in logicalNames)
-                        if (!tablegroups.TryAdd(logicalName, g))
+                        if (!tablegroups.TryAdd(logicalName.Trim(), g.Trim()))
                         {
                             // TODO - replace with logger with other PR
                             Console.WriteLine($"Dublicate logicalname detected: {logicalName} (already in tablegroup '{tablegroups[logicalName]}', dublicate found in group '{g}')");

--- a/Generator/DataverseService.cs
+++ b/Generator/DataverseService.cs
@@ -170,7 +170,7 @@ namespace Generator
 
                     var logicalNames = tables[1].Split(',', StringSplitOptions.RemoveEmptyEntries);
                     foreach (var logicalName in logicalNames)
-                        if (!tablegroups.TryAdd(logicalName.Trim(), g.Trim()))
+                        if (!tablegroups.TryAdd(logicalName.Trim().ToLower(), tables[0].Trim()))
                         {
                             // TODO - replace with logger with other PR
                             Console.WriteLine($"Dublicate logicalname detected: {logicalName} (already in tablegroup '{tablegroups[logicalName]}', dublicate found in group '{g}')");
@@ -218,11 +218,15 @@ namespace Generator
             };
         }
 
-        private static (string? Group, string? Description) GetGroupAndDescription(EntityMetadata entity, IDictionary<string, string>? tableGroups = null)
+        private static (string? Group, string? Description) GetGroupAndDescription(EntityMetadata entity, IDictionary<string, string> tableGroups)
         {
             var description = entity.Description.UserLocalizedLabel?.Label ?? string.Empty;
             if (!description.StartsWith("#"))
+            {
+                if (tableGroups.TryGetValue(entity.LogicalName, out var tablegroup))
+                    return (tablegroup, description);
                 return (null, description);
+            }
 
             var newlineIndex = description.IndexOf("\n");
             if (newlineIndex != -1)
@@ -236,9 +240,6 @@ namespace Generator
             var firstSpace = withoutHashtag.IndexOf(" ");
             if (firstSpace != -1)
                 return (withoutHashtag.Substring(0, firstSpace), withoutHashtag.Substring(firstSpace + 1));
-
-            if (tableGroups != null && tableGroups.TryGetValue(entity.LogicalName, out var tablegroup))
-                return (tablegroup, description);
 
             return (withoutHashtag, null);
         }

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ The pipeline expects a variable group called `DataModel`. It must have the follo
 * WebsiteName: Used for the url of the web app
 * WebsitePassword: Password used by DMV users to login to the generated site.
 * WebsiteSessionSecret: Key to encrypt the session token with (You can set it to whatever you like, but recommended 32 random characters).
+* TableGroups: Enter a semi-colon separated list of group names and for each group a comma-separated list of table schema names within that group. Then this configuration will be used to order the tables in groups in the DMV side-menu. Example: `Org. tables: team, systemuser, businessunit; Sales: opportunity, lead`
 
 ## After deployment
 * Go to portal.azure.com 

--- a/Website/components/Attributes.tsx
+++ b/Website/components/Attributes.tsx
@@ -23,8 +23,8 @@ type SortDirection = 'asc' | 'desc' | null
 type SortColumn = 'displayName' | 'schemaName' | 'type' | 'description' | null
 
 function Attributes({ entity, onSelect }: { entity: EntityType, onSelect: (entity: string) => void }) {
-    const [sortColumn, setSortColumn] = useState<SortColumn>(null)
-    const [sortDirection, setSortDirection] = useState<SortDirection>(null)
+    const [sortColumn, setSortColumn] = useState<SortColumn>("displayName")
+    const [sortDirection, setSortDirection] = useState<SortDirection>("asc")
     const [typeFilter, setTypeFilter] = useState<string>("all")
     const [searchQuery, setSearchQuery] = useState("")
 

--- a/Website/components/Keys.tsx
+++ b/Website/components/Keys.tsx
@@ -11,8 +11,8 @@ type SortColumn = 'name' | 'logicalName' | 'attributes' | null
 type SortDirection = 'asc' | 'desc' | null
 
 function Keys({ entity }: { entity: EntityType }) {
-    const [sortColumn, setSortColumn] = useState<SortColumn>(null)
-    const [sortDirection, setSortDirection] = useState<SortDirection>(null)
+    const [sortColumn, setSortColumn] = useState<SortColumn>("name")
+    const [sortDirection, setSortDirection] = useState<SortDirection>("asc")
     const [searchQuery, setSearchQuery] = useState("")
 
     const handleSort = (column: SortColumn) => {

--- a/Website/components/NavItem.tsx
+++ b/Website/components/NavItem.tsx
@@ -5,7 +5,6 @@ import { SidebarGroup, SidebarGroupLabel, SidebarGroupContent, SidebarMenu, Side
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "./ui/collapsible";
 import { GroupType } from "../lib/Types";
 import { useEffect, useState } from "react";
-import { Label, SelectLabel } from "@radix-ui/react-select";
 
 export default function NavItem({
     group,
@@ -27,8 +26,8 @@ export default function NavItem({
         <SidebarGroup>
             <SidebarGroupLabel asChild>
                 <CollapsibleTrigger
-                    className={`flex items-center w-full gap-2 rounded-md p-2 transition-colors cursor-pointer text-left
-                        ${isExpanded ? 'bg-blue-100 text-blue-900' : 'bg-sidebar-accent text-sidebar-accent-foreground'}
+                    className={`flex items-center w-full gap-2 rounded-md p-2 transition-colors cursor-pointer text-left border
+                        ${isExpanded ? 'bg-blue-100 text-blue-900 border-blue-500' : 'bg-sidebar-accent text-sidebar-accent-foreground'}
                         focus-visible:ring-2 focus-visible:ring-sidebar-ring outline-none`}
                     data-state={isExpanded ? 'open' : 'closed'}
                 >

--- a/Website/components/NavItem.tsx
+++ b/Website/components/NavItem.tsx
@@ -5,6 +5,7 @@ import { SidebarGroup, SidebarGroupLabel, SidebarGroupContent, SidebarMenu, Side
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "./ui/collapsible";
 import { GroupType } from "../lib/Types";
 import { useEffect, useState } from "react";
+import { Label, SelectLabel } from "@radix-ui/react-select";
 
 export default function NavItem({
     group,
@@ -25,9 +26,15 @@ export default function NavItem({
     return <Collapsible open={isExpanded} onOpenChange={setIsExpanded} className="group/collapsible">
         <SidebarGroup>
             <SidebarGroupLabel asChild>
-                <CollapsibleTrigger>
-                    <a className="hover:underline" href={`?selected=${group.Name}`}><span className="font-bold text-base">{group.Name}</span></a>
-                    <ChevronDown className="ml-auto transition-transform group-data-[state=open]/collapsible:rotate-180" />
+                <CollapsibleTrigger
+                    className={`flex items-center w-full gap-2 rounded-md p-2 transition-colors cursor-pointer text-left
+                        ${isExpanded ? 'bg-blue-100 text-blue-900' : 'bg-sidebar-accent text-sidebar-accent-foreground'}
+                        focus-visible:ring-2 focus-visible:ring-sidebar-ring outline-none`}
+                    data-state={isExpanded ? 'open' : 'closed'}
+                >
+                    <a className="flex-1 font-bold text-base text-left" href={`?selected=${group.Name}`}><span>{group.Name}</span></a>
+                    <p className="ml-auto font-semibold text-xs opacity-70">{group.Entities.length}</p>
+                    <ChevronDown className={`ml-2 transition-transform ${isExpanded ? 'rotate-180' : ''}`} />
                 </CollapsibleTrigger>
             </SidebarGroupLabel>
             <CollapsibleContent>

--- a/Website/components/NavItem.tsx
+++ b/Website/components/NavItem.tsx
@@ -22,12 +22,12 @@ export default function NavItem({
         setIsExpanded(isSelected)
     }, [isSelected])
 
-    return <Collapsible open={isExpanded} onOpenChange={setIsExpanded} className="group/collapsible">
-        <SidebarGroup>
+    return <Collapsible open={isExpanded} onOpenChange={setIsExpanded} className={`group/collapsible border m-2 rounded-md ${isExpanded ? 'border-blue-500' : ''}`}>
+        <SidebarGroup className="p-0">
             <SidebarGroupLabel asChild>
                 <CollapsibleTrigger
-                    className={`flex items-center w-full gap-2 rounded-md p-2 transition-colors cursor-pointer text-left border
-                        ${isExpanded ? 'bg-blue-100 text-blue-900 border-blue-500' : 'bg-sidebar-accent text-sidebar-accent-foreground'}
+                    className={`flex items-center w-full gap-2 rounded-md p-2 transition-colors cursor-pointer text-left
+                        ${isExpanded ? 'bg-blue-100 text-blue-900' : 'bg-sidebar-accent text-sidebar-accent-foreground'}
                         focus-visible:ring-2 focus-visible:ring-sidebar-ring outline-none`}
                     data-state={isExpanded ? 'open' : 'closed'}
                 >
@@ -42,7 +42,7 @@ export default function NavItem({
                         {group.Entities.map(entity =>
                             <SidebarMenuItem key={entity.SchemaName}>
                                 <SidebarMenuButton onClick={() => onSelect(entity.SchemaName)}>
-                                    {entity.IconBase64 != null && <span><img className="h-4 w-4" src={`data:image/svg+xml;base64,${entity.IconBase64}`} /></span>}
+                                    {entity.IconBase64 != null && <span><img className="h-4 w-4 ml-2" src={`data:image/svg+xml;base64,${entity.IconBase64}`} /></span>}
                                     <span>{entity.DisplayName}</span>
                                 </SidebarMenuButton>
                             </SidebarMenuItem>)}

--- a/Website/components/Relationships.tsx
+++ b/Website/components/Relationships.tsx
@@ -13,8 +13,8 @@ type SortDirection = 'asc' | 'desc' | null
 type SortColumn = 'name' | 'tableSchema' | 'lookupField' | 'type' | 'behavior' | 'schemaName' | null
 
 function Relationships({ entity, onSelect }: { entity: EntityType, onSelect: (entity: string) => void }) {
-    const [sortColumn, setSortColumn] = useState<SortColumn>(null)
-    const [sortDirection, setSortDirection] = useState<SortDirection>(null)
+    const [sortColumn, setSortColumn] = useState<SortColumn>("name")
+    const [sortDirection, setSortDirection] = useState<SortDirection>("asc")
     const [typeFilter, setTypeFilter] = useState<string>("all")
     const [searchQuery, setSearchQuery] = useState("")
 

--- a/Website/components/ui/sidebar.tsx
+++ b/Website/components/ui/sidebar.tsx
@@ -404,7 +404,7 @@ const SidebarContent = React.forwardRef<
       ref={ref}
       data-sidebar="content"
       className={cn(
-        "flex min-h-0 flex-1 flex-col gap-2 overflow-auto group-data-[collapsible=icon]:overflow-hidden",
+        "flex min-h-0 flex-1 flex-col overflow-auto group-data-[collapsible=icon]:overflow-hidden",
         className
       )}
       {...props}


### PR DESCRIPTION
# Changes
- Attributes, Relationships & Keys sorteret på navn default (WiKi)
- `TableGroups` miljøvariable (PBI 119270)
- Antal på tabeller i grupper i navigation (PBI 119266)
- Mindre UI ændringer
  - Klarer overblik over hvad tabeller hører under hvad grupper i navigation