### PR TITLE
Added IsCustom Attribute & minor changes

### DIFF
--- a/Generator/DTO/Attributes/Attribute.cs
+++ b/Generator/DTO/Attributes/Attribute.cs
@@ -4,6 +4,8 @@ namespace Generator.DTO.Attributes;
 
 public abstract class Attribute
 {
+    public bool IsCustomAttribute { get; set; }
+    public bool IsPrimaryId { get; set; }
     public string DisplayName { get; }
     public string SchemaName { get; }
     public string Description { get; }
@@ -15,6 +17,8 @@ public abstract class Attribute
 
     protected Attribute(AttributeMetadata metadata)
     {
+        IsPrimaryId = metadata.IsPrimaryId ?? false;
+        IsCustomAttribute = metadata.IsCustomAttribute ?? false;
         DisplayName = metadata.DisplayName.UserLocalizedLabel?.Label ?? string.Empty;
         SchemaName = metadata.SchemaName;
         Description = metadata.Description.UserLocalizedLabel?.Label.PrettyDescription() ?? string.Empty;

--- a/Generator/DTO/Attributes/LookupAttribute.cs
+++ b/Generator/DTO/Attributes/LookupAttribute.cs
@@ -20,7 +20,7 @@ internal class LookupAttribute : Attribute
 
         Targets =
             metadata.Targets
-            .Where(target => logicalToSchema.ContainsKey(target))
+            .Where(logicalToSchema.ContainsKey)
             .Select(target => logicalToSchema[target]);
     }
 }

--- a/Generator/DataverseService.cs
+++ b/Generator/DataverseService.cs
@@ -38,19 +38,20 @@ namespace Generator
             client = new ServiceClient(
                 instanceUrl: new Uri(dataverseUrl),
                 tokenProviderFunction: url => TokenProviderFunction(url, cache, logger));
-
-
         }
 
         public async Task<IEnumerable<Record>> GetFilteredMetadata()
         {
             var (publisherPrefix, solutionIds) = await GetSolutionIds();
-            var solutionComponents = await GetSolutionComponents(solutionIds);
-            var entityIdToRootBehavior = solutionComponents.Where(x => x.ComponentType == 1).ToDictionary(x => x.ObjectId, x => x.RootComponentBehavior);
-            var solutionEntityMetadata = await GetEntityMetadata(entityIdToRootBehavior.Keys.ToList());
-            var attributesInSolution = new HashSet<Guid>(solutionComponents.Where(x => x.ComponentType == 2).Select(x => x.ObjectId));
-            var rolesInSolution = solutionComponents.Where(solutionComponents => solutionComponents.ComponentType == 20).Select(x => x.ObjectId).ToList();
-            var logicalNameToKeys = solutionEntityMetadata.ToDictionary(
+            var solutionComponents = await GetSolutionComponents(solutionIds); // (id, type)
+
+            var entitiesInSolution = solutionComponents.Where(x => x.ComponentType == 1).Select(x => x.ObjectId).ToList();
+            var attributesInSolution = solutionComponents.Where(x => x.ComponentType == 2).Select(x => x.ObjectId).ToHashSet();
+            var rolesInSolution = solutionComponents.Where(x => x.ComponentType == 20).Select(x => x.ObjectId).ToList();
+
+            var entitiesInSolutionMetadata = await GetEntityMetadata(entitiesInSolution);
+
+            var logicalNameToKeys = entitiesInSolutionMetadata.ToDictionary(
                 entity => entity.LogicalName,
                 entity => entity.Keys.Select(key => new Key(
                     key.DisplayName.UserLocalizedLabel?.Label ?? key.DisplayName.LocalizedLabels.First().Label,
@@ -58,18 +59,13 @@ namespace Generator
                     key.KeyAttributes)
                 ).ToList());
 
-            var relevantEntities = solutionEntityMetadata.Where(e => entityIdToRootBehavior.ContainsKey(e.MetadataId!.Value)).ToList();
-            var logicalNameToSecurityRoles = await GetSecurityRoles(rolesInSolution, relevantEntities.ToDictionary(x => x.LogicalName, x => x.Privileges));
-            var entityLogicalNamesInSolution =
-                relevantEntities
-                .Select(e => e.LogicalName)
-                .ToHashSet();
+            var logicalNameToSecurityRoles = await GetSecurityRoles(rolesInSolution, entitiesInSolutionMetadata.ToDictionary(x => x.LogicalName, x => x.Privileges));
+            var entityLogicalNamesInSolution = entitiesInSolutionMetadata.Select(e => e.LogicalName).ToHashSet();
 
             logger.LogInformation("There are {Count} entities in the solution.", entityLogicalNamesInSolution.Count);
-
             // Collect all referenced entities from attributes and add (needed for lookup attributes)
             var relatedEntityLogicalNames = new HashSet<string>();
-            foreach (var entity in solutionEntityMetadata)
+            foreach (var entity in entitiesInSolutionMetadata)
             {
                 var entityLogicalNamesOutsideSolution = entity.Attributes
                     .OfType<LookupAttributeMetadata>()
@@ -78,20 +74,19 @@ namespace Generator
                     .Where(target => !entityLogicalNamesInSolution.Contains(target));
                 foreach (var target in entityLogicalNamesOutsideSolution) relatedEntityLogicalNames.Add(target);
             }
-
             logger.LogInformation("There are {Count} entities referenced outside the solution.", relatedEntityLogicalNames.Count);
             var referencedEntityMetadata = await GetEntityMetadataByLogicalName(relatedEntityLogicalNames.ToList());
 
-            var allEntityMetadata = solutionEntityMetadata.Concat(referencedEntityMetadata).ToList();
+            var allEntityMetadata = entitiesInSolutionMetadata.Concat(referencedEntityMetadata).ToList();
             var entityIconMap = await GetEntityIconMap(allEntityMetadata);
 
             var records =
-                solutionEntityMetadata
+                entitiesInSolutionMetadata
                 .Select(x => new
                 {
                     EntityMetadata = x,
                     RelevantAttributes =
-                        x.GetRelevantAttributes(entityIdToRootBehavior, attributesInSolution, publisherPrefix, entityLogicalNamesInSolution)
+                        x.GetRelevantAttributes()
                         .Where(x => x.DisplayName.UserLocalizedLabel?.Label != null)
                         .ToList(),
                     RelevantManyToMany =
@@ -103,7 +98,7 @@ namespace Generator
                 .Where(x => x.EntityMetadata.DisplayName.UserLocalizedLabel?.Label != null)
                 .ToList();
 
-            var logicalToSchema = allEntityMetadata.ToDictionary(x => x.LogicalName, x => new ExtendedEntityInformation { Name = x.SchemaName, IsInSolution = solutionEntityMetadata.Any(e => e.LogicalName == x.LogicalName) });
+            var logicalToSchema = allEntityMetadata.ToDictionary(x => x.LogicalName, x => new ExtendedEntityInformation { Name = x.SchemaName, IsInSolution = entitiesInSolutionMetadata.Any(e => e.LogicalName == x.LogicalName) });
             var attributeLogicalToSchema = allEntityMetadata.ToDictionary(x => x.LogicalName, x => x.Attributes?.ToDictionary(attr => attr.LogicalName, attr => attr.DisplayName.UserLocalizedLabel?.Label ?? attr.SchemaName) ?? []);
 
             return records
@@ -117,13 +112,10 @@ namespace Generator
                         x.EntityMetadata,
                         x.RelevantAttributes,
                         x.RelevantManyToMany,
-                        entityIdToRootBehavior,
-                        attributesInSolution,
-                        publisherPrefix,
                         logicalToSchema,
                         attributeLogicalToSchema,
-                        securityRoles ?? new List<SecurityRole>(),
-                        keys ?? new List<Key>(),
+                        securityRoles ?? [],
+                        keys ?? [],
                         entityIconMap,
                         configuration);
                 });
@@ -134,9 +126,6 @@ namespace Generator
             EntityMetadata entity,
             List<AttributeMetadata> relevantAttributes,
             List<ManyToManyRelationshipMetadata> relevantManyToMany,
-            Dictionary<Guid, int> entityIdToRootBehavior,
-            HashSet<Guid> attributesInSolution,
-            string publisherPrefix,
             Dictionary<string, ExtendedEntityInformation> logicalToSchema,
             Dictionary<string, Dictionary<string, string>> attributeLogicalToSchema,
             List<SecurityRole> securityRoles,
@@ -343,7 +332,7 @@ namespace Generator
             return (publisher.GetAttributeValue<string>("customizationprefix"), resp.Entities.Select(e => e.GetAttributeValue<Guid>("solutionid")).ToList());
         }
 
-        public async Task<IEnumerable<(Guid ObjectId, int ComponentType, int RootComponentBehavior)>> GetSolutionComponents(List<Guid> solutionIds)
+        public async Task<IEnumerable<(Guid ObjectId, int ComponentType)>> GetSolutionComponents(List<Guid> solutionIds)
         {
             var entityQuery = new QueryExpression("solutioncomponent")
             {
@@ -352,7 +341,7 @@ namespace Generator
                 {
                     Conditions =
                     {
-                        new ConditionExpression("componenttype", ConditionOperator.In, new List<int>() { 1, 2, 20 }),
+                        new ConditionExpression("componenttype", ConditionOperator.In, new List<int>() { 1, 2, 20 }), // entity, attribute, role (https://learn.microsoft.com/en-us/power-apps/developer/data-platform/reference/entities/solutioncomponent)
                         new ConditionExpression("solutionid", ConditionOperator.In, solutionIds)
                     }
                 }
@@ -361,7 +350,7 @@ namespace Generator
             return
                 (await client.RetrieveMultipleAsync(entityQuery))
                 .Entities
-                .Select(e => (e.GetAttributeValue<Guid>("objectid"), e.GetAttributeValue<OptionSetValue>("componenttype").Value, e.Contains("rootcomponentbehavior") ? e.GetAttributeValue<OptionSetValue>("rootcomponentbehavior").Value : -1))
+                .Select(e => (e.GetAttributeValue<Guid>("objectid"), e.GetAttributeValue<OptionSetValue>("componenttype").Value))
                 .ToList();
         }
 

--- a/Generator/MetadataExtensions.cs
+++ b/Generator/MetadataExtensions.cs
@@ -1,162 +1,21 @@
-﻿using Microsoft.PowerPlatform.Dataverse.Client;
-using Microsoft.Xrm.Sdk.Messages;
-using Microsoft.Xrm.Sdk.Metadata;
-using System.Diagnostics;
+﻿using Microsoft.Xrm.Sdk.Metadata;
 
 namespace Generator;
 
 public static class MetadataExtensions
 {
-    public static IEnumerable<AttributeMetadata> GetRelevantAttributes(
-        this EntityMetadata entity,
-        Dictionary<Guid, int> entityIdToRootBehavior,
-        HashSet<Guid> attributesInSolution,
-        string publisherPrefix,
-        HashSet<string> entityLogicalNamesInSolution)
+    public static IEnumerable<AttributeMetadata> GetRelevantAttributes(this EntityMetadata entity) => entity.Attributes.Where(IsCustomOrModifiedStandardField);
+
+    private static readonly Func<AttributeMetadata, bool> IsCustomOrModifiedStandardField = (AttributeMetadata attribute) =>
     {
-        var isRoot = entityIdToRootBehavior[entity.MetadataId!.Value] == 0;
-        var attributesToFilter =
-            isRoot
-                ? entity.Attributes.ToList()
-                : entity.Attributes.Where(a => a.MetadataId != null && attributesInSolution.Contains(a.MetadataId!.Value)).ToList();
+        bool isCustomField = attribute.IsCustomAttribute ?? false;
+        bool hasBeenModified = attribute.ModifiedOn.HasValue && attribute.CreatedOn.HasValue && attribute.ModifiedOn != attribute.CreatedOn;
 
-
-
-        return attributesToFilter
-            .Where(x => !IsInvalidStandardField(x, entity.DisplayName.UserLocalizedLabel?.Label ?? string.Empty));
-    }
-
-    private static bool IsInvalidStandardField(AttributeMetadata attribute, string entityDisplayName)
-    {
-        var displayName = attribute.DisplayName?.UserLocalizedLabel?.Label;
-        var description = attribute.Description?.UserLocalizedLabel?.Label;
-
-        var standardFieldToDefaultName =
-            DefaultFields
-            .Concat(new[]
-            {
-                ( "statecode", ("Status", $"Status of the {entityDisplayName}") ),
-            })
-        .GroupBy(x => x.Item1)
-        .ToDictionary(x => x.Key, x => x.ToList());
-
-        if (standardFieldToDefaultName.TryGetValue(attribute.LogicalName, out var defaultFields))
-        {
-            return defaultFields.Exists(defaultField => 
-                displayName == defaultField.Item2.Item1 &&
-                 description == defaultField.Item2.Item2);
-        }
-
-        if (attribute.LogicalName.EndsWith("_base"))
-        {
-            return true;
-        }
-
-        if (attribute.LogicalName == "statuscode" && 
-            description == $"Reason for the status of the {entityDisplayName}" &&
-            IsStandardStatusOptions(attribute))
-        {
-            return true;
-        }
-
-        return false;
-    }
-
-    private static bool IsStandardStatusOptions(AttributeMetadata attribute)
-    {
-        if (attribute is StatusAttributeMetadata metadata)
-        {
-            return metadata.OptionSet.Options.All(x => x.Value == 1 || x.Value == 2);
-        }
-
-        return false;
-    }
+        return isCustomField || hasBeenModified;
+    };
 
     internal static string PrettyDescription(this string description) =>
         description
             .Replace("\"", @"”")
             .Replace("\n", " ");
-
-    private static List<(string LogicalName, (string DefaultDisplayName, string DefaultDescription) StandardValues)> DefaultFields = new()
-        {
-            ( "activityadditionalparams", ("Activity Additional Parameters", "Additional information provided by the external application as JSON. For internal use only.") ),
-            ( "activityid", ("Activity", "Unique identifier of the activity.") ),
-            ( "activitytypecode", ("Activity Type", "Type of activity.") ),
-            ( "actualdurationminutes", ("Actual Duration", "Actual duration of the activity in minutes.") ),
-            ( "actualend", ("Actual End", "Actual end time of the activity.") ),
-            ( "actualstart", ("Actual Start", "Actual start time of the activity.") ),
-            ( "bcc", ("BCC", "Blind Carbon-copy (bcc) recipients of the activity.") ),
-            ( "cc", ("CC", "Carbon-copy (cc) recipients of the activity.") ),
-            ( "community", ("Social Channel", "Shows how contact about the social activity originated, such as from Twitter or Facebook. This field is read-only.") ),
-            ( "createdby", ("Created By", "Unique identifier of the user who created the activity.") ),
-            ( "createdby", ("Created By", "Unique identifier of the user who created the record.") ),
-            ( "createdon", ("Created On", "Date and time when the record was created.") ),
-            ( "createdon", ("Date Created", "Date and time when the activity was created.") ),
-            ( "createdonbehalfby", ("Created By (Delegate)", "Unique identifier of the delegate user who created the activity.") ),
-            ( "createdonbehalfby", ("Created By (Delegate)", "Unique identifier of the delegate user who created the activitypointer.") ),
-            ( "createdonbehalfby", ("Created By (Delegate)", "Unique identifier of the delegate user who created the record.") ),
-            ( "customers", ("Customers", "Customer with which the activity is associated.") ),
-            ( "description", ("Description", "Description of the activity.") ),
-            ( "deliverylastattemptedon", ("Date Delivery Last Attempted", "Date and time when the delivery of the activity was last attempted.") ),
-            ( "deliveryprioritycode", ("Delivery Priority", "Priority of delivery of the activity to the email server.") ),
-            ( "exchangeitemid", ("Exchange Item ID", "The message id of activity which is returned from Exchange Server.") ),
-            ( "exchangerate", ("Exchange Rate", "Exchange rate for the currency associated with the activitypointer with respect to the base currency.") ),
-            ( "exchangerate", ("Exchange Rate", "Exchange rate for the currency associated with the entity with respect to the base currency.") ),
-            ( "exchangeweblink", ("Exchange WebLink", "Shows the web link of Activity of type email.") ),
-            ( "from", ("From", "Person who the activity is from.") ),
-            ( "importsequencenumber", ("Import Sequence Number", "Sequence number of the import that created this record.") ),
-            ( "instancetypecode", ("Recurring Instance Type", "Type of instance of a recurring series.") ),
-            ( "isbilled", ("Is Billed", "Information regarding whether the activity was billed as part of resolving a case.") ),
-            ( "ismapiprivate", ("Is Private", "For internal use only.") ),
-            ( "isregularactivity", ("Is Regular Activity", "Information regarding whether the activity is a regular activity type or event type.") ),
-            ( "isworkflowcreated", ("Is Workflow Created", "Information regarding whether the activity was created from a workflow rule.") ),
-            ( "lastonholdtime", ("Last On Hold Time", "Contains the date and time stamp of the last on hold time.") ),
-            ( "leftvoicemail", ("Left Voice Mail", "Left the voice mail") ),
-            ( "modifiedby", ("Modified By", "Unique identifier of user who last modified the activity.") ),
-            ( "modifiedby", ("Modified By", "Unique identifier of the user who modified the record.") ),
-            ( "modifiedon", ("Last Updated", "Date and time when activity was last modified.") ),
-            ( "modifiedon", ("Modified On", "Date and time when the record was modified.") ),
-            ( "modifiedonbehalfby", ("Modified By (Delegate)", "Unique identifier of the delegate user who last modified the activitypointer.") ),
-            ( "modifiedonbehalfby", ("Modified By (Delegate)", "Unique identifier of the delegate user who modified the record.") ),
-            ( "onholdtime", ("On Hold Time (Minutes)", "Shows how long, in minutes, that the record was on hold.") ),
-            ( "optionalattendees", ("Optional Attendees", "List of optional attendees for the activity.") ),
-            ( "organizer", ("Organizer", "Person who organized the activity.") ),
-            ( "overriddencreatedon", ("Record Created On", "Date and time that the record was migrated.") ),
-            ( "ownerid", ( "Owner", "Owner Id") ),
-            ( "ownerid", ( "Owner", "Unique identifier of the user or team who owns the activity.") ),
-            ( "owningbusinessunit", ("Owning Business Unit", "Unique identifier for the business unit that owns the record") ),
-            ( "owningbusinessunit", ("Owning Business Unit", "Unique identifier of the business unit that owns the activity.") ),
-            ( "owningteam", ("Owning Team", "Unique identifier for the team that owns the record.") ),
-            ( "owningteam", ("Owning Team", "Unique identifier of the team that owns the activity.") ),
-            ( "owninguser", ("Owning User", "Unique identifier for the user that owns the record.") ),
-            ( "owninguser", ("Owning User", "Unique identifier of the user that owns the activity.") ),
-            ( "partners", ("Outsource Vendors", "Outsource vendor with which activity is associated.") ),
-            ( "postponeactivityprocessinguntil", ("Delay activity processing until", "For internal use only.") ),
-            ( "prioritycode", ("Priority", "Priority of the activity.") ),
-            ( "processid", ("Process", "Unique identifier of the Process.") ),
-            ( "regardingobjectid", ("Regarding", "Unique identifier of the object with which the activity is associated.") ),
-            ( "requiredattendees", ("Required Attendees", "List of required attendees for the activity.") ),
-            ( "resources", ("Resources", "Users or facility/equipment that are required for the activity.") ),
-            ( "scheduleddurationminutes", ("Scheduled Duration", "Scheduled duration of the activity, specified in minutes.") ),
-            ( "scheduledend", ("Due Date", "Scheduled end time of the activity.") ),
-            ( "scheduledstart", ("Start Date", "Scheduled start time of the activity.") ),
-            ( "sendermailboxid", ("Sender's Mailbox", "Unique identifier of the mailbox associated with the sender of the email message.") ),
-            ( "senton", ("Date Sent", "Date and time when the activity was sent.") ),
-            ( "seriesid", ("Series Id", "Uniqueidentifier specifying the id of recurring series of an instance.") ),
-            ( "serviceid", ("Service", "Unique identifier of an associated service.") ),
-            ( "slaid", ("SLA", "Choose the service level agreement (SLA) that you want to apply to the case record.") ),
-            ( "slainvokedid", ("Last SLA applied", "Last SLA that was applied to this case. This field is for internal use only.") ),
-            ( "sortdate", ("Sort Date", "Shows the date and time by which the activities are sorted.") ),
-            ( "stageid", ( "(Deprecated) Process Stage", "Unique identifier of the Stage.") ),
-            ( "statecode", ("Activity Status", $"Status of the activity.") ),
-            ( "subject", ("Subject", "Subject associated with the activity.") ),
-            ( "timezoneruleversionnumber", ("Time Zone Rule Version Number", "For internal use only.") ),
-            ( "to", ("To", "Person who is the receiver of the activity.") ),
-            ( "transactioncurrencyid", ("Currency", "Unique identifier of the currency associated with the activitypointer.") ),
-            ( "transactioncurrencyid", ("Currency", "Unique identifier of the currency associated with the entity.") ),
-            ( "traversedpath", ("(Deprecated) Traversed Path", "For internal use only.") ),
-            ( "utcconversiontimezonecode", ("UTC Conversion Time Zone Code", "Time zone code that was in use when the record was created.") ),
-            ( "versionnumber", ("Version Number", "Version number of the activity.") ),
-            ( "versionnumber", ("Version Number", "Version Number") ),
-        };
 }

--- a/Generator/MetadataExtensions.cs
+++ b/Generator/MetadataExtensions.cs
@@ -4,15 +4,16 @@ namespace Generator;
 
 public static class MetadataExtensions
 {
-    public static IEnumerable<AttributeMetadata> GetRelevantAttributes(this EntityMetadata entity) => entity.Attributes.Where(IsCustomOrModifiedStandardField);
-
-    private static readonly Func<AttributeMetadata, bool> IsCustomOrModifiedStandardField = (AttributeMetadata attribute) =>
+    public static IEnumerable<AttributeMetadata> GetRelevantAttributes(this EntityMetadata entity, HashSet<Guid> attributesInSolution, Dictionary<Guid, int> rootComponentBehaviour)
     {
-        bool isCustomField = attribute.IsCustomAttribute.HasValue && attribute.IsCustomAttribute.Value;
-        bool hasBeenModified = attribute.ModifiedOn.HasValue && attribute.CreatedOn.HasValue && attribute.ModifiedOn != attribute.CreatedOn;
+        // If rootcomponentbehaviour is 0 that means all attributes are included in the solution and we cannot find them via solutioncomponents, even if they are there.
+        var attributesToFilter =
+            rootComponentBehaviour[entity.MetadataId!.Value] == 0
+                ? entity.Attributes.ToList()
+                : entity.Attributes.Where(a => a.MetadataId != null && attributesInSolution.Contains(a.MetadataId!.Value)).ToList();
 
-        return isCustomField || hasBeenModified;
-    };
+        return attributesToFilter;
+    }
 
     internal static string PrettyDescription(this string description) =>
         description

--- a/Generator/MetadataExtensions.cs
+++ b/Generator/MetadataExtensions.cs
@@ -8,7 +8,7 @@ public static class MetadataExtensions
 
     private static readonly Func<AttributeMetadata, bool> IsCustomOrModifiedStandardField = (AttributeMetadata attribute) =>
     {
-        bool isCustomField = attribute.IsCustomAttribute ?? false;
+        bool isCustomField = attribute.IsCustomAttribute.HasValue && attribute.IsCustomAttribute.Value;
         bool hasBeenModified = attribute.ModifiedOn.HasValue && attribute.CreatedOn.HasValue && attribute.ModifiedOn != attribute.CreatedOn;
 
         return isCustomField || hasBeenModified;

--- a/Website/components/Attributes.tsx
+++ b/Website/components/Attributes.tsx
@@ -4,7 +4,7 @@ import { EntityType, AttributeType } from "@/lib/Types"
 import { TableHeader, TableRow, TableHead, TableBody, TableCell, Table } from "./ui/table"
 import { Button } from "./ui/button"
 import { useState } from "react"
-import { ArrowUpDown, ArrowUp, ArrowDown, Search, X } from "lucide-react"
+import { ArrowUpDown, ArrowUp, ArrowDown, Search, X, PencilOff, Pencil } from "lucide-react"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "./ui/select"
 import { Input } from "./ui/input"
 import { AttributeDetails } from "./entity/AttributeDetails"
@@ -26,6 +26,7 @@ function Attributes({ entity, onSelect }: { entity: EntityType, onSelect: (entit
     const [sortColumn, setSortColumn] = useState<SortColumn>("displayName")
     const [sortDirection, setSortDirection] = useState<SortDirection>("asc")
     const [typeFilter, setTypeFilter] = useState<string>("all")
+    const [hideStandardFields, setHideStandardFields] = useState<boolean>(true)
     const [searchQuery, setSearchQuery] = useState("")
 
     const handleSort = (column: SortColumn) => {
@@ -60,6 +61,8 @@ function Attributes({ entity, onSelect }: { entity: EntityType, onSelect: (entit
                 (attr.Description?.toLowerCase().includes(query) ?? false)
             )
         }
+
+        if (hideStandardFields) filteredAttributes = filteredAttributes.filter(attr => attr.IsCustomAttribute);
 
         if (!sortColumn || !sortDirection) return filteredAttributes
 
@@ -140,6 +143,17 @@ function Attributes({ entity, onSelect }: { entity: EntityType, onSelect: (entit
                     ))}
                 </SelectContent>
             </Select>
+            <Button
+                variant="destructive"
+                size="icon"
+                onClick={() => setHideStandardFields(!hideStandardFields)}
+                className="h-10 w-10 bg-gray-100 hover:bg-gray-300 text-gray-500 hover:text-gray-700"
+                title="Control customfields"
+            >
+                {
+                    hideStandardFields ? <PencilOff className="w-4 h-4" /> : <Pencil className="w-4 h-4" />
+                }
+            </Button>
             {(searchQuery || typeFilter !== "all") && (
                 <Button
                     variant="ghost"

--- a/Website/components/attributes/BooleanAttribute.tsx
+++ b/Website/components/attributes/BooleanAttribute.tsx
@@ -1,19 +1,49 @@
 import { BooleanAttributeType } from "@/lib/Types"
+import { CheckCircle, Circle } from "lucide-react"
 
 export default function BooleanAttribute({ attribute }: { attribute: BooleanAttributeType }) {
     return (
         <div className="flex flex-col gap-1">
             <div className="flex items-center gap-2">
                 <span className="font-bold">Boolean</span>
-                <span className="text-gray-500 text-sm">
-                    (Default: {attribute.DefaultValue === true ? attribute.TrueLabel : attribute.FalseLabel})
-                </span>
+                {attribute.DefaultValue !== null && (
+                    <span className="text-xs bg-green-100 text-green-700 px-1.5 py-0.5 rounded-full flex items-center gap-1">
+                        <CheckCircle className="w-3 h-3" />
+                        Default: {attribute.DefaultValue === true ? attribute.TrueLabel : attribute.FalseLabel}
+                    </span>
+                )}
             </div>
-            <div className="grid grid-cols-[1fr_auto] gap-x-4 gap-y-1 pl-4">
-                <span>{attribute.TrueLabel}</span>
-                <span>True</span>
-                <span>{attribute.FalseLabel}</span>
-                <span>False</span>
+            <div className="space-y-1">
+                <div className="flex items-center justify-between py-1">
+                    <div className="flex items-center gap-1">
+                        {attribute.DefaultValue === true ? (
+                            <CheckCircle className="w-3 h-3 text-green-600" />
+                        ) : (
+                            <Circle className="w-3 h-3 text-gray-400" />
+                        )}
+                        <span className="text-sm">{attribute.TrueLabel}</span>
+                    </div>
+                    <div className="flex items-center gap-2">
+                        <span className="text-xs bg-gray-200 text-gray-700 px-1.5 py-0.5 rounded font-mono">
+                            True
+                        </span>
+                    </div>
+                </div>
+                <div className="flex items-center justify-between py-1">
+                    <div className="flex items-center gap-1">
+                        {attribute.DefaultValue === false ? (
+                            <CheckCircle className="w-3 h-3 text-green-600" />
+                        ) : (
+                            <Circle className="w-3 h-3 text-gray-400" />
+                        )}
+                        <span className="text-sm">{attribute.FalseLabel}</span>
+                    </div>
+                    <div className="flex items-center gap-2">
+                        <span className="text-xs bg-gray-200 text-gray-700 px-1.5 py-0.5 rounded font-mono">
+                            False
+                        </span>
+                    </div>
+                </div>
             </div>
         </div>
     )

--- a/Website/components/attributes/ChoiceAttribute.tsx
+++ b/Website/components/attributes/ChoiceAttribute.tsx
@@ -1,5 +1,6 @@
 import { ChoiceAttributeType } from "@/lib/Types"
 import { formatNumberSeperator } from "@/lib/utils"
+import { CheckCircle, Circle } from "lucide-react"
 
 export default function ChoiceAttribute({ attribute }: { attribute: ChoiceAttributeType }) {
     return (
@@ -7,25 +8,41 @@ export default function ChoiceAttribute({ attribute }: { attribute: ChoiceAttrib
             <div className="flex items-center gap-2">
                 <span className="font-bold">{attribute.Type}-select</span>
                 {attribute.DefaultValue !== null && attribute.DefaultValue !== -1 && (
-                    <span className="text-gray-500 text-sm">
-                        (Default: {attribute.Options.find(o => o.Value === attribute.DefaultValue)?.Name})
+                    <span className="text-xs bg-green-100 text-green-700 px-1.5 py-0.5 rounded-full flex items-center gap-1">
+                        <CheckCircle className="w-3 h-3" />
+                        Default: {attribute.Options.find(o => o.Value === attribute.DefaultValue)?.Name}
                     </span>
                 )}
             </div>
-            <div className="grid grid-cols-[1fr_auto] gap-x-4 gap-y-1 pl-4">
+            <div className="space-y-1">
                 {attribute.Options.map(option => (
-                    <div key={option.Value} className="contents">
-                        <div className="flex items-center gap-2">
-                            <span>{option.Name}</span>
-                        </div>
-                        <div className="flex items-center gap-2 justify-end">
-                            <span>{formatNumberSeperator(option.Value)}</span>
-                            {option.Color && (
-                                <span className="w-4 h-4" style={{ backgroundColor: option.Color }}></span>
-                            )}
+                    <div key={option.Value}>
+                        <div className="flex items-center justify-between py-1">
+                            <div className="flex items-center gap-2">
+                                <div className="flex items-center gap-1">
+                                    {option.Value === attribute.DefaultValue ? (
+                                        <CheckCircle className="w-3 h-3 text-green-600" />
+                                    ) : (
+                                        <Circle className="w-3 h-3 text-gray-400" />
+                                    )}
+                                    <span className="text-sm">{option.Name}</span>
+                                </div>
+                                {option.Color && (
+                                    <div 
+                                        className="w-3 h-3 rounded-full border border-gray-300 shadow-sm" 
+                                        style={{ backgroundColor: option.Color }}
+                                        title={`Color: ${option.Color}`}
+                                    />
+                                )}
+                            </div>
+                            <div className="flex items-center gap-2">
+                                <span className="text-xs bg-gray-200 text-gray-700 px-1.5 py-0.5 rounded font-mono">
+                                    {formatNumberSeperator(option.Value)}
+                                </span>
+                            </div>
                         </div>
                         {option.Description && (
-                            <div className="col-span-2 text-sm text-gray-500 italic pl-4 break-words">
+                            <div className="text-xs text-gray-600 italic pl-6 break-words">
                                 {option.Description}
                             </div>
                         )}

--- a/Website/components/attributes/LookupAttribute.tsx
+++ b/Website/components/attributes/LookupAttribute.tsx
@@ -1,23 +1,30 @@
 import { LookupAttributeType } from "@/lib/Types"
 import { Button } from "../ui/button"
-import { Label } from "@radix-ui/react-label"
+import { FileSearch, FileX2 } from "lucide-react"
 
 export default function LookupAttribute({ attribute, onSelect }: { attribute: LookupAttributeType, onSelect: (entity: string) => void }) {
     return <>
         <p className="font-bold">Lookup</p>
-        <div className="flex flex-col items-start">
+        <div className="flex flex-wrap gap-1 mt-1">
             {attribute.Targets
                 .map(target => target.IsInSolution ? 
                     <Button
                         key={target.Name}
-                        variant="ghost"
-                        className="p-0 text-base text-blue-600 underline dark:text-blue-500 hover:no-underline"
-                        onClick={() => onSelect(target.Name)}>{target.Name}
+                        variant="outline"
+                        size="sm"
+                        className="h-6 px-2 text-xs flex items-center gap-1 hover:bg-blue-50 hover:border-blue-300"
+                        onClick={() => onSelect(target.Name)}
+                    >
+                        <FileSearch className="w-3 h-3" />
+                        {target.Name}
                     </Button> : 
-                    <Label 
+                    <div 
                         key={target.Name} 
-                        className="p-0 text-base dark:text-gray-300 hover:no-underline">{target.Name}
-                    </Label>)}
+                        className="h-6 px-2 text-xs flex items-center gap-1 bg-gray-100 text-gray-600 rounded border"
+                    >
+                        <FileX2 className="w-3 h-3" />
+                        {target.Name}
+                    </div>)}
         </div>
     </>
 }

--- a/Website/components/entity/EntityHeader.tsx
+++ b/Website/components/entity/EntityHeader.tsx
@@ -16,7 +16,7 @@ export function EntityHeader({ entity }: { entity: EntityType }) {
                 </div>
                 <div className="min-w-0">
                     <a 
-                        className="group flex items-center gap-2 hover:no-underline" 
+                        className="group flex items-center gap-2 hover:no-underline flex-wrap" 
                         href={`?selected=${entity.SchemaName}`}
                     >
                         <h2 className="text-2xl font-semibold text-gray-900 group-hover:text-blue-600 transition-colors">

--- a/Website/lib/Types.ts
+++ b/Website/lib/Types.ts
@@ -41,6 +41,8 @@ export const enum CalculationMethods {
 }
 
 export type BaseAttribute = {
+    IsPrimaryId: boolean;
+    IsCustomAttribute: boolean;
     DisplayName: string,
     SchemaName: string,
     Description: string | null,


### PR DESCRIPTION
The goal was to find a way to filter away standard fields that were unchanged. 
This is not possible, so ended up with a simple filter toggle on customfields in the frontend. 

## Changes:
- Minor UI changes to Lookup, Choice and Boolean
- Allowed table logicalname to wrap to next line (mobile)

## Refactor:
- Removed hardcoded attribute displaynames and description (did not support localization). I spent a great time to see if there was no way to check for alterations to a name, but found nothing in the SDK, Solutionfile or unsupported APIs.

If interested, I had a few findings on my journey:
- The query for solutioncomponents does not return all attributes in the solution (why? - a solutioncomponent is not made for an attribute if you include the entire entity metadata (visible via rootcomponentbehavior on the entity) - its MS way to reduce the amount of entries created in this table. And maybe something to do with layering.)
- I thought looking at how the Make portal does it in the network requests, I could just reverse engineer it, but it seems MS has its own system table called msdyn_solutioncomponentsymmaries, however any query to this table will return an empty list.
- To check if a standard field attribute has its displayname or description altered, I started with a naive approach that was (if modifed != created date) - this does not work at all. Magnus had hardcoded all the displaynames and description and used these for comparison, but this did not work in a danish system. I gave up on finding a systematic way to check for modifications to standard fields.
- The customization.xml sometimes and sometimes not will exclude the displayname and description if not altered. But again not a consistent method.