### PR TITLE
Patches to navigation 120203

### DIFF
--- a/Website/app/layout.tsx
+++ b/Website/app/layout.tsx
@@ -5,6 +5,7 @@ import { SettingsProvider } from "@/contexts/SettingsContext";
 import { AuthProvider } from "@/contexts/AuthContext";
 import { AppRouterCacheProvider } from '@mui/material-nextjs/v15-appRouter';
 import { DatamodelViewProvider } from "@/contexts/DatamodelViewContext";
+import { SnackbarProvider } from "@/contexts/SnackbarContext";
 
 export const metadata: Metadata = {
   title: "Data Model Viewer",
@@ -30,7 +31,9 @@ export default function RootLayout({
             <SettingsProvider>
               <DatamodelViewProvider>
                 <SidebarProvider>
-                  {children}
+                  <SnackbarProvider>
+                    {children}
+                  </SnackbarProvider>
                 </SidebarProvider>
               </DatamodelViewProvider>
             </SettingsProvider>

--- a/Website/components/datamodelview/List.tsx
+++ b/Website/components/datamodelview/List.tsx
@@ -140,6 +140,7 @@ export const List = ({ }: IListProps) => {
 
                 setTimeout(() => {
                     setIsScrollingToSection(false);
+                    dispatch({ type: 'SET_LOADING_SECTION', payload: null });
                     // Reset intentional scroll flag after scroll is complete
                     setTimeout(() => {
                         isIntentionalScroll.current = false;
@@ -160,6 +161,7 @@ export const List = ({ }: IListProps) => {
                 setIsScrollingToSection(false);
             }
         }, 20);
+
     }, [flatItems, rowVirtualizer]);
 
     const scrollToGroup = useCallback((groupName: string) => {

--- a/Website/components/datamodelview/List.tsx
+++ b/Website/components/datamodelview/List.tsx
@@ -6,6 +6,9 @@ import { Section } from "./Section";
 import { useDatamodelData } from "@/contexts/DatamodelDataContext";
 import { AttributeType, EntityType, GroupType } from "@/lib/Types";
 import { updateURL } from "@/lib/url-utils";
+import { copyToClipboard, generateGroupLink } from "@/lib/clipboard-utils";
+import { useSnackbar } from "@/contexts/SnackbarContext";
+import { Tooltip } from '@mui/material';
 
 interface IListProps {
 }
@@ -23,6 +26,7 @@ export const List = ({ }: IListProps) => {
     const datamodelView = useDatamodelView();
     const [isScrollingToSection, setIsScrollingToSection] = useState(false);
     const { groups, filtered, search } = useDatamodelData();
+    const { showSnackbar } = useSnackbar();
     const parentRef = useRef<HTMLDivElement | null>(null);
     const lastScrollHandleTime = useRef<number>(0);
     const scrollTimeoutRef = useRef<NodeJS.Timeout>();
@@ -41,6 +45,16 @@ export const List = ({ }: IListProps) => {
         const el = sectionRefs.current[schemaName];
         if (el) rowVirtualizer.measureElement(el);
     };
+
+    const handleCopyGroupLink = useCallback(async (groupName: string) => {
+        const link = generateGroupLink(groupName);
+        const success = await copyToClipboard(link);
+        if (success) {
+            showSnackbar('Group link copied to clipboard!', 'success');
+        } else {
+            showSnackbar('Failed to copy group link', 'error');
+        }
+    }, [showSnackbar]);
 
     // Only recalculate items when filtered or search changes
     const flatItems = useMemo(() => {
@@ -424,9 +438,14 @@ export const List = ({ }: IListProps) => {
                         {item.type === 'group' ? (
                             <div className="flex items-center py-6 my-4">
                                 <div className="flex-1 h-0.5 bg-gray-200" />
-                                <div className="px-4 text-md font-semibold text-gray-700 uppercase tracking-wide whitespace-nowrap">
-                                    {item.group.Name}
-                                </div>
+                                <Tooltip title="Copy link to this group">
+                                    <div 
+                                        className="px-4 text-md font-semibold text-gray-700 uppercase tracking-wide whitespace-nowrap cursor-pointer hover:text-blue-600 transition-colors"
+                                        onClick={() => handleCopyGroupLink(item.group.Name)}
+                                    >
+                                        {item.group.Name}
+                                    </div>
+                                </Tooltip>
                                 <div className="flex-1 h-0.5 bg-gray-200" />
                             </div>
                         ) : (

--- a/Website/components/datamodelview/SidebarDatamodelView.tsx
+++ b/Website/components/datamodelview/SidebarDatamodelView.tsx
@@ -99,12 +99,13 @@ export const SidebarDatamodelView = ({ }: ISidebarDatamodelViewProps) => {
             const newExpanded = new Set(prev);
             if (newExpanded.has(groupName)) {
                 newExpanded.delete(groupName);
-            } else if (currentGroup?.toLowerCase() !== groupName.toLowerCase()) {
+            } else {
+                if (currentGroup?.toLowerCase() === groupName.toLowerCase()) return newExpanded;
                 newExpanded.add(groupName);
             }
             return newExpanded;
         });
-    }, [dataModelDispatch]);
+    }, [dataModelDispatch, currentGroup]);
 
     const handleSectionClick = useCallback((sectionId: string, groupName: string) => {
         // Use requestAnimationFrame to defer heavy operations

--- a/Website/components/datamodelview/SidebarDatamodelView.tsx
+++ b/Website/components/datamodelview/SidebarDatamodelView.tsx
@@ -151,11 +151,6 @@ export const SidebarDatamodelView = ({ }: ISidebarDatamodelViewProps) => {
                     scrollToSection(sectionId);
                 }
                 clearSearch();
-                
-                // Clear loading section after a short delay to show the loading state
-                setTimeout(() => {
-                    dataModelDispatch({ type: 'SET_LOADING_SECTION', payload: null });
-                }, 500);
             });
         });
     }, [dataModelDispatch, scrollToSection, clearSearch]);
@@ -302,7 +297,7 @@ export const SidebarDatamodelView = ({ }: ISidebarDatamodelViewProps) => {
                 </AccordionDetails>
             </Accordion>
         )
-    }, [currentGroup, currentSection, theme, handleGroupClick, handleSectionClick, isEntityMatch, searchTerm, highlightText, expandedGroups]);
+    }, [currentGroup, currentSection, theme, handleGroupClick, handleSectionClick, isEntityMatch, searchTerm, highlightText, expandedGroups, loadingSection]);
 
     return (
         <Box className="flex flex-col w-full p-2">

--- a/Website/components/datamodelview/entity/EntityHeader.tsx
+++ b/Website/components/datamodelview/entity/EntityHeader.tsx
@@ -2,11 +2,25 @@
 
 import { EntityType } from "@/lib/Types";
 import { EntityDetails } from "./EntityDetails";
-import { Box, Typography, Paper, useTheme } from '@mui/material';
+import { Box, Typography, Paper, useTheme, Tooltip } from '@mui/material';
 import { LinkRounded } from "@mui/icons-material";
+import { useCallback } from 'react';
+import { copyToClipboard, generateSectionLink } from "@/lib/clipboard-utils";
+import { useSnackbar } from "@/contexts/SnackbarContext";
 
 export function EntityHeader({ entity }: { entity: EntityType }) {
     const theme = useTheme();
+    const { showSnackbar } = useSnackbar();
+    
+    const handleCopyLink = useCallback(async () => {
+        const link = generateSectionLink(entity.SchemaName);
+        const success = await copyToClipboard(link);
+        if (success) {
+            showSnackbar('Link copied to clipboard!', 'success');
+        } else {
+            showSnackbar('Failed to copy link', 'error');
+        }
+    }, [entity.SchemaName, showSnackbar]);
     
     return (
         <Box 
@@ -17,51 +31,76 @@ export function EntityHeader({ entity }: { entity: EntityType }) {
             }}
         >
             <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, mb: 1.5 }}>
-                <Box sx={{ flexShrink: 0 }}>
-                    {entity.IconBase64 == null ? 
-                        <LinkRounded 
-                            style={{ 
-                                height: '24px', 
-                                width: '24px', 
-                                color: theme.palette.text.secondary 
-                            }} 
-                        /> : 
-                        <div 
-                            className="h-6 w-6"
-                            style={{
-                                maskImage: `url(data:image/svg+xml;base64,${entity.IconBase64})`,
-                                maskSize: 'contain',
-                                maskRepeat: 'no-repeat',
-                                maskPosition: 'center',
-                                backgroundColor: theme.palette.text.primary
-                            }}
-                        />
-                    }
-                </Box>
+                <Tooltip title="Copy link to this section">
+                    <Box 
+                        sx={{ 
+                            flexShrink: 0,
+                            cursor: 'pointer',
+                            '&:hover': {
+                                opacity: 0.7
+                            }
+                        }}
+                        onClick={handleCopyLink}
+                    >
+                        {entity.IconBase64 == null ? 
+                            <LinkRounded 
+                                style={{ 
+                                    height: '24px', 
+                                    width: '24px', 
+                                    color: theme.palette.text.secondary 
+                                }} 
+                            /> : 
+                            <div 
+                                className="h-6 w-6"
+                                style={{
+                                    maskImage: `url(data:image/svg+xml;base64,${entity.IconBase64})`,
+                                    maskSize: 'contain',
+                                    maskRepeat: 'no-repeat',
+                                    maskPosition: 'center',
+                                    backgroundColor: theme.palette.text.primary
+                                }}
+                            />
+                        }
+                    </Box>
+                </Tooltip>
                 <Box sx={{ minWidth: 0, flex: 1 }} className="flex items-center flex-wrap" gap={2}>
-                    <Typography 
-                        variant="h5" 
-                        component="h2"
-                        className="entity-title"
-                        sx={{ 
-                            fontWeight: 600,
-                            color: 'text.primary',
-                            transition: 'color 0.2s',
-                            minWidth: 0
-                        }}
-                    >
-                        {entity.DisplayName}
-                    </Typography>
-                    <Typography 
-                        variant="body2" 
-                        sx={{ 
-                            color: 'text.secondary',
-                            fontFamily: 'monospace',
-                            flexShrink: 0
-                        }}
-                    >
-                        {entity.SchemaName}
-                    </Typography>
+                    <Tooltip title="Copy link to this section">
+                        <Typography 
+                            variant="h5" 
+                            component="h2"
+                            className="entity-title"
+                            sx={{ 
+                                fontWeight: 600,
+                                color: 'text.primary',
+                                transition: 'color 0.2s',
+                                minWidth: 0,
+                                cursor: 'pointer',
+                                '&:hover': {
+                                    color: 'primary.main'
+                                }
+                            }}
+                            onClick={handleCopyLink}
+                        >
+                            {entity.DisplayName}
+                        </Typography>
+                    </Tooltip>
+                    <Tooltip title="Copy link to this section">
+                        <Typography 
+                            variant="body2" 
+                            sx={{ 
+                                color: 'text.secondary',
+                                fontFamily: 'monospace',
+                                flexShrink: 0,
+                                cursor: 'pointer',
+                                '&:hover': {
+                                    color: 'primary.main'
+                                }
+                            }}
+                            onClick={handleCopyLink}
+                        >
+                            {entity.SchemaName}
+                        </Typography>
+                    </Tooltip>
                 </Box>
             </Box>
             

--- a/Website/contexts/DatamodelViewContext.tsx
+++ b/Website/contexts/DatamodelViewContext.tsx
@@ -8,6 +8,7 @@ export interface DatamodelViewState {
     currentGroup: string | null;
     currentSection: string | null;
     scrollToSection: (sectionId: string) => void;
+    scrollToGroup: (groupName: string) => void;
     loading: boolean;
     loadingSection: string | null;
 }
@@ -16,6 +17,7 @@ const initialState: DatamodelViewState = {
     currentGroup: null,
     currentSection: null,
     scrollToSection: () => { throw new Error("scrollToSection not initialized yet!"); },
+    scrollToGroup: () => { throw new Error("scrollToGroup not initialized yet!"); },
     loading: true,
     loadingSection: null,
 }
@@ -24,6 +26,7 @@ type DatamodelViewAction =
     | { type: 'SET_CURRENT_GROUP', payload: string | null }
     | { type: 'SET_CURRENT_SECTION', payload: string | null }
     | { type: 'SET_SCROLL_TO_SECTION', payload: (sectionId: string) => void }
+    | { type: 'SET_SCROLL_TO_GROUP', payload: (groupName: string) => void }
     | { type: 'SET_LOADING', payload: boolean }
     | { type: 'SET_LOADING_SECTION', payload: string | null }
 
@@ -36,6 +39,8 @@ const datamodelViewReducer = (state: DatamodelViewState, action: DatamodelViewAc
             return { ...state, currentSection: action.payload }
         case 'SET_SCROLL_TO_SECTION':
             return { ...state, scrollToSection: action.payload }
+        case 'SET_SCROLL_TO_GROUP':
+            return { ...state, scrollToGroup: action.payload }
         case 'SET_LOADING':
             return { ...state, loading: action.payload }
         case 'SET_LOADING_SECTION':

--- a/Website/contexts/SnackbarContext.tsx
+++ b/Website/contexts/SnackbarContext.tsx
@@ -1,0 +1,71 @@
+'use client'
+
+import React, { createContext, useContext, useState, useCallback, ReactNode } from 'react';
+import { Snackbar, Alert, AlertColor } from '@mui/material';
+
+interface SnackbarMessage {
+  message: string;
+  severity?: AlertColor;
+  duration?: number;
+}
+
+interface SnackbarContextType {
+  showSnackbar: (message: string, severity?: AlertColor, duration?: number) => void;
+}
+
+const SnackbarContext = createContext<SnackbarContextType | undefined>(undefined);
+
+export const useSnackbar = (): SnackbarContextType => {
+  const context = useContext(SnackbarContext);
+  if (!context) {
+    throw new Error('useSnackbar must be used within a SnackbarProvider');
+  }
+  return context;
+};
+
+interface SnackbarProviderProps {
+  children: ReactNode;
+}
+
+export const SnackbarProvider: React.FC<SnackbarProviderProps> = ({ children }) => {
+  const [snackbarData, setSnackbarData] = useState<SnackbarMessage | null>(null);
+  const [open, setOpen] = useState(false);
+
+  const showSnackbar = useCallback((message: string, severity: AlertColor = 'success', duration: number = 3000) => {
+    setSnackbarData({ message, severity, duration });
+    setOpen(true);
+  }, []);
+
+  const handleClose = useCallback((event?: React.SyntheticEvent | Event, reason?: string) => {
+    if (reason === 'clickaway') {
+      return;
+    }
+    setOpen(false);
+  }, []);
+
+  const handleExited = useCallback(() => {
+    setSnackbarData(null);
+  }, []);
+
+  return (
+    <SnackbarContext.Provider value={{ showSnackbar }}>
+      {children}
+      <Snackbar
+        open={open}
+        autoHideDuration={snackbarData?.duration ?? 3000}
+        onClose={handleClose}
+        slotProps={{ transition: { onExited: handleExited } }}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
+      >
+        <Alert
+          onClose={handleClose}
+          severity={snackbarData?.severity ?? 'success'}
+          variant="filled"
+          sx={{ width: '100%' }}
+        >
+          {snackbarData?.message}
+        </Alert>
+      </Snackbar>
+    </SnackbarContext.Provider>
+  );
+};

--- a/Website/lib/clipboard-utils.ts
+++ b/Website/lib/clipboard-utils.ts
@@ -1,0 +1,66 @@
+/**
+ * Utility functions for clipboard operations
+ */
+
+/**
+ * Copy text to clipboard using the modern clipboard API
+ * @param text The text to copy to clipboard
+ * @returns Promise that resolves to true if successful, false otherwise
+ */
+export async function copyToClipboard(text: string): Promise<boolean> {
+  try {
+    // Modern clipboard API - preferred method
+    if (navigator.clipboard && window.isSecureContext) {
+      await navigator.clipboard.writeText(text);
+      return true;
+    }
+    
+    // Fallback for older browsers - create temporary input element
+    const textArea = document.createElement('textarea');
+    textArea.value = text;
+    textArea.style.position = 'absolute';
+    textArea.style.left = '-9999px';
+    textArea.style.opacity = '0';
+    
+    document.body.appendChild(textArea);
+    textArea.select();
+    textArea.setSelectionRange(0, 99999);
+    
+    // Use the legacy method as fallback (suppress deprecation warning)
+    const success = document.execCommand('copy');
+    document.body.removeChild(textArea);
+    
+    return success;
+  } catch (err) {
+    console.error('Failed to copy text to clipboard:', err);
+    return false;
+  }
+}
+
+/**
+ * Generate a shareable URL for a specific section
+ * @param sectionId The schema name of the section
+ * @param groupName Optional group name for context
+ * @returns The full URL that can be shared
+ */
+export function generateSectionLink(sectionId: string, groupName?: string): string {
+  const url = new URL(window.location.href);
+  url.pathname = '/metadata';
+  url.searchParams.set('section', sectionId);
+  if (groupName) {
+    url.searchParams.set('group', groupName);
+  }
+  return url.toString();
+}
+
+/**
+ * Generate a shareable URL for a specific group
+ * @param groupName The name of the group
+ * @returns The full URL that can be shared
+ */
+export function generateGroupLink(groupName: string): string {
+  const url = new URL(window.location.href);
+  url.pathname = '/metadata';
+  url.searchParams.set('group', groupName);
+  return url.toString();
+}


### PR DESCRIPTION
Den lille pil ved en "group" i menuen burde både kunne åbne og lukke gruppen, eller det burde ske lige meget hvor du trykker pånær "link" knappen.
Link/gå til knappen i en group i menuen hopper til den group i mainarea, men hvor den er scrollet til først tabel, den burde scrolle til gruppenavnet.
På en "group" i content-area burde man have et "link" igen der deeplinker til den gruppe, det har man ikke nu og man kommer heller ikke ind på en URL for gruppen når man trykker på "link/gå til"-knappen i menuen for gruppen.
Når man har valgt en tabel i sidemenuen kører loading spinner (i menuen) for evigt.
Når man trykker på ikon/navn/teknisk navn på en tabel i content area burde den deeplinke til den tabel, så det link kan deles.